### PR TITLE
Fix mail form path and field names

### DIFF
--- a/Information_company.html
+++ b/Information_company.html
@@ -149,11 +149,11 @@
 				</article>
 				<article class="col-4">
 					<h3>Сообщение для почты.</h3>
-					<form action="PHP/send.php" method="post">
-						<input type="text" name="name" placeholder="Имя">
-						<textarea class="textarea" name="msg" placeholder="Сообщение"></textarea>
-						<input type="submit" name="otprav" value="Отправить">
-					</form>
+                                       <form action="processing/send.php" method="post">
+                                               <input type="text" name="name_user" placeholder="Имя">
+                                               <textarea class="textarea" name="message" placeholder="Сообщение"></textarea>
+                                               <input type="submit" name="otprav" value="Отправить">
+                                       </form>
 					
 				</article>
 			</section>

--- a/contact.html
+++ b/contact.html
@@ -105,11 +105,11 @@
 				</article>
 				<article class="col-4">
 					<h3>Сообщение для почты.</h3>
-					<form action="PHP/send.php" method="post">
-						<input type="text" name="name" placeholder="Имя">
-						<textarea class="textarea" name="msg" placeholder="Сообщение"></textarea>
-						<input type="submit" name="otprav" value="Отправить">
-					</form>
+                                       <form action="processing/send.php" method="post">
+                                               <input type="text" name="name_user" placeholder="Имя">
+                                               <textarea class="textarea" name="message" placeholder="Сообщение"></textarea>
+                                               <input type="submit" name="otprav" value="Отправить">
+                                       </form>
 					
 				</article>
 			</section>

--- a/events.html
+++ b/events.html
@@ -157,11 +157,11 @@
 				</article>
 				<article class="col-4">
 					<h3>Сообщение для почты.</h3>
-					<form action="PHP/send.php" method="post">
-						<input type="text" name="name" placeholder="Имя">
-						<textarea class="textarea" name="msg" placeholder="Сообщение"></textarea>
-						<input type="submit" name="otprav" value="Отправить">
-					</form>
+                                       <form action="processing/send.php" method="post">
+                                               <input type="text" name="name_user" placeholder="Имя">
+                                               <textarea class="textarea" name="message" placeholder="Сообщение"></textarea>
+                                               <input type="submit" name="otprav" value="Отправить">
+                                       </form>
 
 				</article>
 			</section>

--- a/price.html
+++ b/price.html
@@ -127,11 +127,11 @@
 				</article>
 				<article class="col-4">
 					<h3>Сообщение для почты.</h3>
-					<form action="PHP/send.php" method="post">
-						<input type="text" name="name" placeholder="Имя">
-						<textarea class="textarea" name="msg" placeholder="Сообщение"></textarea>
-						<input type="submit" name="otprav" value="Отправить">
-					</form>
+                                       <form action="processing/send.php" method="post">
+                                               <input type="text" name="name_user" placeholder="Имя">
+                                               <textarea class="textarea" name="message" placeholder="Сообщение"></textarea>
+                                               <input type="submit" name="otprav" value="Отправить">
+                                       </form>
 					
 				</article>
 			</section>

--- a/students.html
+++ b/students.html
@@ -114,11 +114,11 @@
 				</article>
 				<article class="col-4">
 					<h3>Сообщение для почты.</h3>
-					<form action="PHP/send.php" method="post">
-						<input type="text" name="name" placeholder="Имя">
-						<textarea class="textarea" name="msg" placeholder="Сообщение"></textarea>
-						<input type="submit" name="otprav" value="Отправить">
-					</form>
+                                       <form action="processing/send.php" method="post">
+                                               <input type="text" name="name_user" placeholder="Имя">
+                                               <textarea class="textarea" name="message" placeholder="Сообщение"></textarea>
+                                               <input type="submit" name="otprav" value="Отправить">
+                                       </form>
 					
 				</article>
 			</section>

--- a/teacher.html
+++ b/teacher.html
@@ -86,11 +86,11 @@
 				</article>
 				<article class="col-4">
 					<h3>Сообщение для почты.</h3>
-					<form action="PHP/send.php" method="post">
-						<input type="text" name="name" placeholder="Имя">
-						<textarea class="textarea" name="msg" placeholder="Сообщение"></textarea>
-						<input type="submit" name="otprav" value="Отправить">
-					</form>
+                                       <form action="processing/send.php" method="post">
+                                               <input type="text" name="name_user" placeholder="Имя">
+                                               <textarea class="textarea" name="message" placeholder="Сообщение"></textarea>
+                                               <input type="submit" name="otprav" value="Отправить">
+                                       </form>
 					
 				</article>
 			</section>


### PR DESCRIPTION
## Summary
- fix HTML forms to point to `processing/send.php`
- fix form field names to match PHP script

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6840416353808328a4ada5e7d35e9c31