### PR TITLE
Add PHPUnit setup and tests for send.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,11 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^9.5",
+        "php-mock/php-mock-phpunit": "^2.0"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "": "tests/"
+        }
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php">
+    <testsuites>
+        <testsuite name="Project Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,13 @@
 # Git and Github
 
 Crash for WebSites
+
+## Running tests
+
+After running `composer install` to fetch development dependencies, execute:
+
+```
+vendor/bin/phpunit
+```
+
+This runs the PHPUnit test suite located in the `tests` directory.

--- a/tests/SendPhpTest.php
+++ b/tests/SendPhpTest.php
@@ -1,0 +1,27 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use phpmock\phpunit\PHPMock;
+
+class SendPhpTest extends TestCase
+{
+    use PHPMock;
+
+    public function testSendPhpRunsAndCallsMail()
+    {
+        $called = false;
+        $mailMock = $this->getFunctionMock('', 'mail');
+        $mailMock->expects($this->once())
+            ->willReturnCallback(function() use (&$called) {
+                $called = true;
+                return true;
+            });
+
+        $_POST['name_user'] = 'John Doe';
+        $_POST['message'] = 'Hello world';
+
+        $result = include __DIR__ . '/../processing/send.php';
+
+        $this->assertEquals(1, $result);
+        $this->assertTrue($called, 'mail() should be called and return true');
+    }
+}


### PR DESCRIPTION
## Summary
- add composer.json with phpunit and php-mock
- document how to run tests in README
- add phpunit config file
- provide SendPhpTest using PHPMock to mock `mail`

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6842e3ccaf9c8328b6c1cbad88173d7c